### PR TITLE
Refactor discovery and apply flows to use browser sessions

### DIFF
--- a/developer_tasks/1-tasks-replace-httpx-with-browser-use.md
+++ b/developer_tasks/1-tasks-replace-httpx-with-browser-use.md
@@ -24,10 +24,10 @@ The `apply` command currently fetches the application form's HTML using a backgr
 - **File to Modify:** `src/job_ai_auto_apply_ui/orchestrator.py`
 
 #### Tasks:
-- [ ] **1.1: Remove the `httpx`-based `_default_form_fetch` function.**
+- [X] **1.1: Remove the `httpx`-based `_default_form_fetch` function.**
   - This function is the source of the issue in the `apply` flow. It should be completely removed.
 
-- [ ] **1.2: Modify the `iter_apply_events` function to use `browser-use`.**
+- [X] **1.2: Modify the `iter_apply_events` function to use `browser-use`.**
   - In the loop where it processes each `item` from the queue, you must initiate a browser session to fetch the form HTML.
   - **Pattern to Follow:** The `_load_search_results_with_browser` function in `src/job_ai_auto_apply_ui/job_discovery.py` provides the correct pattern for starting a `BrowserSession`.
   - **Implementation Steps:**
@@ -46,10 +46,10 @@ The `discover` command correctly uses `browser-use` for the main Google search, 
 - **File to Modify:** `src/job_ai_auto_apply_ui/job_discovery.py`
 
 #### Tasks:
-- [ ] **2.1: Remove the `httpx`-based `_default_fetch` function.**
+- [X] **2.1: Remove the `httpx`-based `_default_fetch` function.**
   - This function is used as a fallback and for fetching posting details. It should be removed to enforce a browser-only workflow.
 
-- [ ] **2.2: Modify `discover_jobs` to use the existing browser session for fetching posting details.**
+- [X] **2.2: Modify `discover_jobs` to use the existing browser session for fetching posting details.**
   - The function already has an active `BrowserSession` from `_load_search_results_with_browser`. This session should be reused.
   - **Implementation Steps:**
     1.  The `discover_jobs` function needs access to the `session` object created in `_load_search_results_with_browser`. You will need to refactor the code to pass the active `session` into `discover_jobs` or manage the session at a higher level.
@@ -60,23 +60,23 @@ The `discover` command correctly uses `browser-use` for the main Google search, 
     6.  Close the tab after you are done to conserve resources: `await posting_page.close()`.
   - **Reference:** This aligns with the "multi-tab navigation" concept mentioned for `job_discovery` in `reference_files/mvp-architecture.md`.
 
-- [ ] **2.3: Remove the `httpx` fallback logic in `discover_jobs`.**
+- [X] **2.3: Remove the `httpx` fallback logic in `discover_jobs`.**
   - The `try...except` block that calls `_load_search_results_with_browser` and then falls back to `_default_fetch` should be removed. If the browser-based discovery fails, the command should fail clearly, as this is a critical failure, not something to be worked around with a less reliable method.
 
 ### Part 3: Update and Write Tests
 
-- [ ] **3.1: Update existing tests.**
+- [X] **3.1: Update existing tests.**
   - Any unit or integration tests that were mocking `httpx` calls (like `_default_form_fetch`) will now fail. These tests must be updated to mock the `BrowserSession` and its methods (`start`, `goto`, `evaluate`, `stop`, etc.) instead.
 
-- [ ] **3.2: Write a new integration test.**
+- [X] **3.2: Write a new integration test.**
   - Create a new integration test that runs the `apply` command for a single item from a fixture. This test should assert that a `BrowserSession` is created and that it navigates to the correct URL. You can use mocking to prevent the browser from actually running while still asserting that the correct calls were made.
 
 ### Part 4: Final Polish & Verification
 
-- [ ] **4.1: Run the linter.**
+- [X] **4.1: Run the linter.**
   - After making all code changes, run `ruff check .` and fix any new issues.
 
-- [ ] **4.2: Run the full test suite.**
+- [X] **4.2: Run the full test suite.**
   - Ensure all existing and new tests pass by running `pytest`.
 
 ---

--- a/src/job_ai_auto_apply_ui/job_discovery.py
+++ b/src/job_ai_auto_apply_ui/job_discovery.py
@@ -16,7 +16,6 @@ from html.parser import HTMLParser
 from typing import ClassVar
 from urllib.parse import parse_qs, urlencode, urljoin, urlparse
 
-import httpx
 from browser_use.browser.session import BrowserSession
 
 from .application_queue import ApplicationItem, JobDetails
@@ -25,7 +24,7 @@ from .telemetry import log_event
 
 LOGGER = logging.getLogger(__name__)
 
-_BROWSER_TIMEOUT_SECONDS = 8.0
+_BROWSER_TIMEOUT_SECONDS = 20.0
 _BROWSER_DISABLED_MODES = {"off", "disabled", "http"}
 
 
@@ -279,102 +278,104 @@ def discover_jobs(
     profile: Profile,
     window_hours: int,
     cap: int,
-    fetch_search: Callable[[str], str] | None = None,
-    fetch_posting: Callable[[str], str] | None = None,
     browser_factory: Callable[[Profile], BrowserSession] | None = None,
 ) -> list[ApplicationItem]:
     """Discover Lever job postings for the given profile."""
+
     search_url = build_search_url(profile, window_hours)
     source_query = build_search_query(profile)
-    fetch_posting = fetch_posting or _default_fetch
 
-    if fetch_search is not None:
-        try:
-            html_document = fetch_search(search_url)
-        except Exception as exc:  # pragma: no cover - dependency override failure
-            LOGGER.exception("Failed to fetch Google results: %s", exc)
-            log_event("discover.error", profile=profile.id, reason="google_fetch_failed")
-            return []
-    else:
-        if _browser_mode() in _BROWSER_DISABLED_MODES:
-            LOGGER.info("Browser discovery disabled via environment; using HTTP fallback")
-            log_event("discover.browser_disabled", profile=profile.id)
-            try:
-                html_document = _default_fetch(search_url)
-            except Exception as exc:  # pragma: no cover - network failure
-                LOGGER.exception("Failed to fetch Google results: %s", exc)
-                log_event("discover.error", profile=profile.id, reason="google_fetch_failed")
-                return []
-        else:
-            try:
-                html_document = _load_search_results_with_browser(
-                    profile=profile,
-                    search_url=search_url,
-                    browser_factory=browser_factory,
-                )
-            except Exception as exc:  # pragma: no cover - runtime/browser failure
-                LOGGER.exception("Browser-based discovery failed: %s", exc)
-                log_event(
-                    "discover.browser_failed",
-                    profile=profile.id,
-                    reason=type(exc).__name__,
-                )
-                try:
-                    html_document = _default_fetch(search_url)
-                except Exception as fallback_exc:  # pragma: no cover - network failure
-                    LOGGER.exception("Fallback HTTP fetch failed: %s", fallback_exc)
-                    log_event("discover.error", profile=profile.id, reason="google_fetch_failed")
-                    return []
+    if _browser_mode() in _BROWSER_DISABLED_MODES:
+        LOGGER.info("Browser discovery disabled via environment toggle")
+        log_event("discover.browser_disabled", profile=profile.id)
+        return []
 
-    parser = _GoogleResultsParser()
-    parser.feed(html_document)
-    results = parser.results[: max(cap, 0)]
-
-    items: list[ApplicationItem] = []
-    for result in results:
-        parsed_url = urlparse(result.url)
-        if parsed_url.scheme not in {"http", "https"}:
-            LOGGER.warning("Skipping non-http result URL: %s", result.url)
-            log_event(
-                "discover.result_skipped",
-                profile=profile.id,
-                url=result.url,
-                reason="invalid_scheme",
-            )
-            continue
-        try:
-            posting_html = fetch_posting(result.url)
-        except Exception as exc:  # pragma: no cover - network failure
-            LOGGER.warning("Failed to fetch posting %s: %s", result.url, exc)
-            log_event(
-                "discover.posting_fetch_failed",
-                profile=profile.id,
-                url=result.url,
-            )
-            details = JobDetails(source_query=source_query, source_rank=result.rank)
-            title = result.title
-        else:
-            posting_parser = _LeverPostingParser(result.url)
-            posting_parser.feed(posting_html)
-            details = posting_parser.build_details()
-            details.source_query = source_query
-            details.source_rank = result.rank
-            title = posting_parser.title() or result.title
-            if result.snippet and not details.posting_excerpt:
-                details.posting_excerpt = result.snippet
-            if details.apply_url is None:
-                details.apply_url = result.url
-
-        company = result.company_slug()
-        item = ApplicationItem.new_from_discovery(
-            url=result.url,
-            company=company,
-            title=title,
-            details=details,
-            source_query=source_query,
-            source_rank=result.rank,
+    async def _run() -> list[ApplicationItem]:
+        html_document, session = await _load_search_results_with_browser(
+            profile=profile,
+            search_url=search_url,
+            browser_factory=browser_factory,
         )
-        items.append(item)
+        try:
+            parser = _GoogleResultsParser()
+            parser.feed(html_document)
+            results = parser.results[: max(cap, 0)]
+
+            items: list[ApplicationItem] = []
+            for result in results:
+                parsed_url = urlparse(result.url)
+                if parsed_url.scheme not in {"http", "https"}:
+                    LOGGER.warning("Skipping non-http result URL: %s", result.url)
+                    log_event(
+                        "discover.result_skipped",
+                        profile=profile.id,
+                        url=result.url,
+                        reason="invalid_scheme",
+                    )
+                    continue
+
+                posting_page = await session.new_page()
+                try:
+                    await posting_page.goto(result.url)
+                    posting_html = await _capture_page_html(posting_page)
+                except Exception as exc:  # pragma: no cover - runtime/browser failure
+                    LOGGER.warning("Failed to fetch posting %s: %s", result.url, exc)
+                    log_event(
+                        "discover.posting_fetch_failed",
+                        profile=profile.id,
+                        url=result.url,
+                    )
+                    details = JobDetails(
+                        source_query=source_query,
+                        source_rank=result.rank,
+                    )
+                    title = result.title
+                else:
+                    posting_parser = _LeverPostingParser(result.url)
+                    posting_parser.feed(posting_html)
+                    details = posting_parser.build_details()
+                    details.source_query = source_query
+                    details.source_rank = result.rank
+                    title = posting_parser.title() or result.title
+                    if result.snippet and not details.posting_excerpt:
+                        details.posting_excerpt = result.snippet
+                    if details.apply_url is None:
+                        details.apply_url = result.url
+                finally:
+                    with suppress(Exception):
+                        await posting_page.close()
+
+                company = result.company_slug()
+                item = ApplicationItem.new_from_discovery(
+                    url=result.url,
+                    company=company,
+                    title=title,
+                    details=details,
+                    source_query=source_query,
+                    source_rank=result.rank,
+                )
+                items.append(item)
+
+            log_event("discover.browser_complete", profile=profile.id)
+            return items
+        finally:
+            with suppress(Exception):
+                await session.stop()
+
+    try:
+        items = asyncio.run(asyncio.wait_for(_run(), timeout=_BROWSER_TIMEOUT_SECONDS))
+    except asyncio.TimeoutError as exc:  # pragma: no cover - defensive timeout guard
+        LOGGER.exception("Browser discovery timed out: %s", exc)
+        log_event("discover.browser_failed", profile=profile.id, reason="timeout")
+        raise TimeoutError("Browser discovery timed out") from exc
+    except Exception as exc:  # pragma: no cover - defensive logging
+        LOGGER.exception("Browser-based discovery failed: %s", exc)
+        log_event(
+            "discover.browser_failed",
+            profile=profile.id,
+            reason=type(exc).__name__,
+        )
+        raise
 
     log_event(
         "discover.results",
@@ -384,21 +385,6 @@ def discover_jobs(
         search_url=search_url,
     )
     return items
-
-
-def _default_fetch(url: str) -> str:
-    """Fetch a URL using httpx and return the response text."""
-    headers = {
-        "User-Agent": (
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-            "AppleWebKit/537.36 (KHTML, like Gecko) "
-            "Chrome/120.0.0.0 Safari/537.36"
-        )
-    }
-    with httpx.Client(timeout=10.0) as client:
-        response = client.get(url, headers=headers)
-        response.raise_for_status()
-        return response.text
 
 
 def _window_to_tbs(window_hours: int) -> str:
@@ -416,12 +402,12 @@ def _window_to_tbs(window_hours: int) -> str:
     return ""
 
 
-def _load_search_results_with_browser(
+async def _load_search_results_with_browser(
     *,
     profile: Profile,
     search_url: str,
     browser_factory: Callable[[Profile], BrowserSession] | None,
-) -> str:
+) -> tuple[str, BrowserSession]:
     """Load Google search results in a visible browser session."""
 
     factory = browser_factory or _default_browser_factory
@@ -432,29 +418,22 @@ def _load_search_results_with_browser(
         browser=getattr(session, "channel", None),
     )
 
-    async def _run() -> str:
-        await session.start()
-        try:
-            page = await session.get_current_page()
-            if page is None:
-                page = await session.new_page()
-            await page.goto(search_url)
-            try:
-                await _wait_for_search_results(page)
-            except TimeoutError:
-                LOGGER.warning("Timed out waiting for Google results to render")
-            html_document = await _capture_page_html(page)
-            return html_document
-        finally:
-            with suppress(Exception):
-                await session.stop()
-
     try:
-        html_document = asyncio.run(asyncio.wait_for(_run(), timeout=_BROWSER_TIMEOUT_SECONDS))
-    except asyncio.TimeoutError as exc:  # pragma: no cover - runtime/browser failure
-        raise TimeoutError("Browser session timed out") from exc
-    log_event("discover.browser_complete", profile=profile.id)
-    return html_document
+        await session.start()
+        page = await session.get_current_page()
+        if page is None:
+            page = await session.new_page()
+        await page.goto(search_url)
+        try:
+            await _wait_for_search_results(page)
+        except TimeoutError:
+            LOGGER.warning("Timed out waiting for Google results to render")
+        html_document = await _capture_page_html(page)
+        return html_document, session
+    except Exception:
+        with suppress(Exception):
+            await session.stop()
+        raise
 
 
 def _default_browser_factory(profile: Profile) -> BrowserSession:

--- a/src/job_ai_auto_apply_ui/orchestrator.py
+++ b/src/job_ai_auto_apply_ui/orchestrator.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
+import io
 import json
 import sys
 from collections.abc import Callable, Iterable, Iterator, Mapping
+from contextlib import redirect_stdout, suppress
 from datetime import UTC, datetime
 from pathlib import Path
 
-import httpx
+from browser_use.browser.session import BrowserSession
 
 from . import job_discovery, profile_manager
 from .application_queue import ApplicationQueue, ApplicationStatus
@@ -19,10 +22,11 @@ from .browser_agent import (
     LeverFormPlan,
     ensure_allowed_domain,
 )
-from .config import load_settings
 from .llm import load_llm_config
 from .profile_manager import Profile, ProfileNotFoundError
 from .telemetry import bind_timeline, log_event
+
+_APPLY_BROWSER_TIMEOUT_SECONDS = 20.0
 
 
 def _print_json(obj: object) -> None:
@@ -189,14 +193,16 @@ def iter_apply_events(
     profile: Profile,
     mode: str,
     *,
-    fetch_form: Callable[[str], str] | None = None,
+    browser_factory: Callable[[Profile, LeverBrowserOptions], BrowserSession] | None = None,
 ) -> Iterator[dict[str, object]]:
     """Yield apply events for streaming to the CLI.
 
     Args:
         profile: Active profile driving the application session.
         mode: ``"auto"`` or ``"supervised"`` mode indicator.
-        fetch_form: Optional callable to retrieve HTML for a posting form.
+        browser_factory: Optional factory that returns a configured
+            :class:`BrowserSession` for fetching form HTML. Primarily used in
+            tests to inject stub sessions.
 
     Yields:
         dict[str, object]: Event payloads following the apply contract schema.
@@ -208,7 +214,6 @@ def iter_apply_events(
     agent = LeverApplyAgent(options=browser_options)
     submitted = 0
     failed = 0
-    fetch_form = fetch_form or _default_form_fetch
     yield {"event": "start", "profile": profile.id}
     pending = queue.pending()
     log_event("apply.pending", profile=profile.id, count=len(pending))
@@ -230,8 +235,13 @@ def iter_apply_events(
         plan_payload: dict[str, object] | None = None
         if apply_url:
             try:
-                form_html = fetch_form(apply_url)
-            except Exception as exc:  # pragma: no cover - network/runtime failure
+                form_html = _fetch_form_with_browser(
+                    profile=profile,
+                    url=apply_url,
+                    options=browser_options,
+                    browser_factory=browser_factory,
+                )
+            except Exception as exc:  # pragma: no cover - runtime/browser failure
                 timeline.warning("form.fetch_failed", error=str(exc), url=apply_url)
                 log_event("apply.form_fetch_failed", profile=profile.id, url=apply_url)
             else:
@@ -372,33 +382,80 @@ def _plan_to_payload(plan: LeverFormPlan) -> dict[str, object]:
     }
 
 
-def _default_form_fetch(url: str) -> str:
-    """Fetch Lever form HTML while enforcing allowed domain safety.
+def _fetch_form_with_browser(
+    *,
+    profile: Profile,
+    url: str,
+    options: LeverBrowserOptions,
+    browser_factory: Callable[[Profile, LeverBrowserOptions], BrowserSession] | None,
+) -> str:
+    """Load Lever form HTML using a browser-use session."""
 
-    Args:
-        url: Target application form URL.
+    ensure_allowed_domain(url, options.allowed_domains)
+    factory = browser_factory or _default_apply_browser_factory
+    session = factory(profile, options)
 
-    Returns:
-        str: Raw HTML contents of the requested form.
+    async def _run() -> str:
+        await session.start()
+        try:
+            page = await session.get_current_page()
+            if page is None:
+                page = await session.new_page()
+            await page.goto(url)
+            html_document = await _capture_page_html(page)
+            return html_document
+        finally:
+            with suppress(Exception):
+                await session.stop()
 
-    Raises:
-        ValueError: If the URL is outside the configured allow-list.
-
-    """
-
-    settings = load_settings()
-    ensure_allowed_domain(url, settings.allowed_domains)
-    headers = {
-        "User-Agent": (
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-            "AppleWebKit/537.36 (KHTML, like Gecko) "
-            "Chrome/120.0.0.0 Safari/537.36"
+    try:
+        return asyncio.run(
+            asyncio.wait_for(_run(), timeout=_APPLY_BROWSER_TIMEOUT_SECONDS)
         )
+    except asyncio.TimeoutError as exc:  # pragma: no cover - defensive timeout guard
+        raise TimeoutError("Timed out loading Lever form") from exc
+
+
+async def _capture_page_html(page) -> str:
+    """Capture the outer HTML of the current page without noisy stdout."""
+
+    with redirect_stdout(io.StringIO()):
+        return await page.evaluate("() => document.documentElement.outerHTML")
+
+
+def _default_apply_browser_factory(
+    profile: Profile, options: LeverBrowserOptions
+) -> BrowserSession:
+    """Return a BrowserSession configured for apply-mode scraping."""
+
+    kwargs = options.to_browser_use_kwargs()
+    kwargs.update(
+        {
+            "headless": False,
+            "channel": _resolve_browser_channel(profile.preferred_browser),
+            "user_data_dir": str(profile.user_data_dir)
+            if profile.user_data_dir
+            else None,
+            "keep_alive": False,
+        }
+    )
+    clean_kwargs = {key: value for key, value in kwargs.items() if value is not None}
+    return BrowserSession(**clean_kwargs)
+
+
+def _resolve_browser_channel(preferred: str | None) -> str | None:
+    if not preferred:
+        return "chrome"
+    normalized = preferred.strip().lower()
+    mapping = {
+        "chrome": "chrome",
+        "google chrome": "chrome",
+        "chromium": "chromium",
+        "msedge": "msedge",
+        "edge": "msedge",
+        "microsoft edge": "msedge",
     }
-    with httpx.Client(timeout=15.0) as client:
-        response = client.get(url, headers=headers)
-        response.raise_for_status()
-        return response.text
+    return mapping.get(normalized, "chrome")
 
 
 def resume_job(job_id: str) -> dict[str, object]:

--- a/tests/integration/test_apply_browser_fetch.py
+++ b/tests/integration/test_apply_browser_fetch.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from job_ai_auto_apply_ui.application_queue import ApplicationItem, ApplicationQueue, JobDetails
+from job_ai_auto_apply_ui.orchestrator import iter_apply_events
+from job_ai_auto_apply_ui.profile_manager import Profile
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+
+
+def test_iter_apply_events_uses_browser_session(monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+    profile = Profile(
+        id="front_end",
+        name="Front End",
+        resume_path=Path("resume.pdf"),
+        defaults={},
+        keywords={},
+        prompts={},
+    )
+
+    queue = ApplicationQueue(profile.id)
+    apply_url = "https://jobs.lever.co/example/123/apply"
+    details = JobDetails(apply_url=apply_url)
+    item = ApplicationItem.new_from_discovery(
+        url="https://jobs.lever.co/example/123",
+        company="example",
+        title="Senior Frontend Engineer",
+        details=details,
+    )
+    queue.enqueue([item])
+
+    form_html = (FIXTURES / "lever_form.html").read_text(encoding="utf-8")
+    stub_session = _StubApplyBrowserSession(form_html)
+
+    events = list(
+        iter_apply_events(
+            profile,
+            "auto",
+            browser_factory=lambda prof, opts: stub_session,
+        )
+    )
+
+    assert stub_session.started is True
+    assert stub_session.stopped is True
+    assert stub_session.visited_urls == [apply_url]
+    assert any(event["event"] == "submitted" for event in events)
+
+
+class _StubApplyPage:
+    def __init__(self, session: "_StubApplyBrowserSession", html: str) -> None:
+        self._session = session
+        self._html = html
+        self.current_url: str | None = None
+
+    async def goto(self, url: str) -> None:
+        self.current_url = url
+        self._session.visited_urls.append(url)
+
+    async def evaluate(self, script: str) -> str:
+        return self._html
+
+    async def close(self) -> None:  # pragma: no cover - helper
+        return None
+
+
+class _StubApplyBrowserSession:
+    channel = "chrome"
+
+    def __init__(self, html: str) -> None:
+        self._html = html
+        self.started = False
+        self.stopped = False
+        self.visited_urls: list[str] = []
+        self._page: _StubApplyPage | None = None
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+    async def get_current_page(self) -> _StubApplyPage | None:
+        return self._page
+
+    async def new_page(self) -> _StubApplyPage:
+        page = _StubApplyPage(self, self._html)
+        if self._page is None:
+            self._page = page
+        return page

--- a/tests/integration/test_lever_details_extract.py
+++ b/tests/integration/test_lever_details_extract.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from job_ai_auto_apply_ui.job_discovery import discover_jobs
+from job_ai_auto_apply_ui.job_discovery import build_search_url, discover_jobs
 from job_ai_auto_apply_ui.profile_manager import Profile
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
@@ -31,12 +31,18 @@ def test_lever_details_extract_populates_job_details() -> None:
     </html>
     """
 
+    search_url = build_search_url(profile, 24)
+    html_map = {
+        search_url: search_html,
+        "https://jobs.lever.co/example/123": posting_html,
+    }
+    stub_session = _StubBrowserSession(html_map)
+
     items = discover_jobs(
         profile=profile,
         window_hours=24,
         cap=3,
-        fetch_search=lambda _: search_html,
-        fetch_posting=lambda _: posting_html,
+        browser_factory=lambda _: stub_session,
     )
 
     assert len(items) == 1
@@ -47,3 +53,61 @@ def test_lever_details_extract_populates_job_details() -> None:
     assert item.details.posting_excerpt
     assert item.details.source_rank == 1
     assert item.details.source_query.startswith("site:jobs.lever.co")
+
+
+class _StubPage:
+    def __init__(self, session: "_StubBrowserSession") -> None:
+        self._session = session
+        self.current_url: str | None = None
+
+    async def goto(self, url: str) -> None:
+        self.current_url = url
+        self._session._record_visit(url)
+
+    async def get_elements_by_css_selector(self, selector: str) -> list[object]:
+        html = self._session.html_for(self.current_url)
+        if "div.g" in selector or "div.MjjYud" in selector:
+            if "class=\"g\"" in html or "class='g'" in html:
+                return [object()]
+            return []
+        return [object()] if html else []
+
+    async def evaluate(self, script: str) -> str:
+        return self._session.html_for(self.current_url)
+
+    async def close(self) -> None:  # pragma: no cover - integration helper
+        return None
+
+
+class _StubBrowserSession:
+    channel = "chrome"
+
+    def __init__(self, html_by_url: dict[str, str]) -> None:
+        self._html_by_url = html_by_url
+        self.started = False
+        self.stopped = False
+        self.visits: list[str] = []
+        self._current_page: _StubPage | None = None
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+    async def get_current_page(self) -> _StubPage | None:
+        return self._current_page
+
+    async def new_page(self) -> _StubPage:
+        page = _StubPage(self)
+        if self._current_page is None:
+            self._current_page = page
+        return page
+
+    def html_for(self, url: str | None) -> str:
+        if not url:
+            return ""
+        return self._html_by_url.get(url, "")
+
+    def _record_visit(self, url: str) -> None:
+        self.visits.append(url)

--- a/tests/unit/test_job_discovery.py
+++ b/tests/unit/test_job_discovery.py
@@ -61,12 +61,18 @@ def test_discover_jobs_parses_results(monkeypatch) -> None:
     </html>
     """
 
+    search_url = build_search_url(profile, 24)
+    html_map = {
+        search_url: search_html,
+        "https://jobs.lever.co/example/123": posting_html,
+    }
+    stub_session = _StubBrowserSession(html_map)
+
     items = discover_jobs(
         profile=profile,
         window_hours=24,
         cap=5,
-        fetch_search=lambda url: search_html,
-        fetch_posting=lambda url: posting_html,
+        browser_factory=lambda _: stub_session,
     )
 
     assert len(items) == 1
@@ -80,27 +86,41 @@ def test_discover_jobs_parses_results(monkeypatch) -> None:
 
 
 class _StubPage:
-    def __init__(self, html: str) -> None:
-        self.html = html
+    def __init__(self, session: "_StubBrowserSession") -> None:
+        self._session = session
+        self.current_url: str | None = None
         self.visited_urls: list[str] = []
+        self.closed = False
 
     async def goto(self, url: str) -> None:
+        self.current_url = url
         self.visited_urls.append(url)
+        self._session._record_visit(url)
 
     async def get_elements_by_css_selector(self, selector: str) -> list[object]:
-        return [object()]
+        html = self._session.html_for(self.current_url)
+        if "div.g" in selector or "div.MjjYud" in selector:
+            if "class=\"g\"" in html or "class='g'" in html:
+                return [object()]
+            return []
+        return [object()] if html else []
 
     async def evaluate(self, script: str) -> str:
-        return self.html
+        return self._session.html_for(self.current_url)
+
+    async def close(self) -> None:
+        self.closed = True
 
 
 class _StubBrowserSession:
     channel = "chrome"
 
-    def __init__(self, html: str) -> None:
-        self.page = _StubPage(html)
+    def __init__(self, html_by_url: dict[str, str]) -> None:
+        self._html_by_url = html_by_url
         self.started = False
         self.stopped = False
+        self.visits: list[str] = []
+        self._current_page: _StubPage | None = None
 
     async def start(self) -> None:
         self.started = True
@@ -108,11 +128,22 @@ class _StubBrowserSession:
     async def stop(self) -> None:
         self.stopped = True
 
-    async def get_current_page(self) -> _StubPage:  # pragma: no cover - exercised indirectly
-        return self.page
+    async def get_current_page(self) -> _StubPage | None:  # pragma: no cover - exercised indirectly
+        return self._current_page
 
-    async def new_page(self) -> _StubPage:  # pragma: no cover - exercised indirectly
-        return self.page
+    async def new_page(self) -> _StubPage:
+        page = _StubPage(self)
+        if self._current_page is None:
+            self._current_page = page
+        return page
+
+    def html_for(self, url: str | None) -> str:
+        if not url:
+            return ""
+        return self._html_by_url.get(url, "")
+
+    def _record_visit(self, url: str) -> None:
+        self.visits.append(url)
 
 
 def test_discover_jobs_uses_browser_session(monkeypatch) -> None:
@@ -131,17 +162,21 @@ def test_discover_jobs_uses_browser_session(monkeypatch) -> None:
     </html>
     """
 
-    stub_session = _StubBrowserSession(search_html)
+    search_url = build_search_url(profile, 24)
+    html_map = {
+        search_url: search_html,
+        "https://jobs.lever.co/example/123": posting_html,
+    }
+    stub_session = _StubBrowserSession(html_map)
 
     items = discover_jobs(
         profile=profile,
         window_hours=24,
         cap=5,
-        fetch_posting=lambda url: posting_html,
         browser_factory=lambda _: stub_session,
     )
 
     assert stub_session.started is True
     assert stub_session.stopped is True
-    assert stub_session.page.visited_urls == [build_search_url(profile, 24)]
+    assert stub_session.visits == [search_url, "https://jobs.lever.co/example/123"]
     assert len(items) == 1


### PR DESCRIPTION
## Summary
- replace httpx-based form fetching in `iter_apply_events` with browser-use sessions and configurable factories
- refactor discovery to reuse the active BrowserSession for posting pages and drop http fallbacks
- update job discovery tests to mock BrowserSession behavior and add an apply integration test validating browser navigation

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddf8d1ba788324bdb9cfa8ab64ff00